### PR TITLE
Enabled Gradle local build caching

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -71,3 +71,9 @@ gradle.taskGraph.whenReady { taskGraph ->
     }
   }
 }
+
+buildCache {
+  local {
+    enabled = !System.getenv().containsKey("CI")
+  }
+}


### PR DESCRIPTION
This PR optimizes local build times by enabling the Gradle's build caching functionality. Build times on the CI won't change.

The run experiment consists in executing two consecutive `clean build`[1]. Without enabling the build cache each execution took on my system over 23 min. After enabling the build cache, the second execution takes less than 10 seconds!

While this is a contrived experiment, enabling the build caching functionality should lend benefits in most situations.

I found out about this while trying [Gradle Enterprise](https://gradle.com/enterprise).

# Current state

## Build Time
A clean build will always trigger the execution of all tasks when the build cache functionality is not explicitly enabled.

<img width="1720" alt="build-performance-without-buildcache" src="https://user-images.githubusercontent.com/703748/229850795-4384bd0a-9689-43d9-b568-04aa2c0b65dd.png">

## Tasks execution
It's interesting to note that despite there are 79 cacheable tasks, all of them must be re-executed every time if the build cache functionality is not explicitly enabled.
<img width="1164" alt="build-performance-avoided-tasks-without-buildcache" src="https://user-images.githubusercontent.com/703748/229851184-788c28fc-ca7e-464d-b0c5-a2c20fe79623.png">

# This PR

## Build Time
Note how build time went down to less than 10 seconds. This because 79 tasks were not executed thanks to having enabled the build cache functionality.
<img width="1720" alt="build-performance-with-buildcache" src="https://user-images.githubusercontent.com/703748/229851503-a96a5a51-8fe4-47f2-9fe1-e9c51a004184.png">

## Tasks execution
<img width="1164" alt="build-performance-avoided-tasks-with-buildcache" src="https://user-images.githubusercontent.com/703748/229854332-6af1950c-5086-4b0d-a771-fea715ed338d.png">

[1] I had to skip the `rat` tasks and I also had to disable a few tests as they would not timeout on my machine.